### PR TITLE
Detailの読み込みをスキップするオプション引数の追加

### DIFF
--- a/bq/csv.go
+++ b/bq/csv.go
@@ -39,7 +39,7 @@ type Details struct {
 	TotalQuantity int       `json:"total_quantity" csv:"total_quantity"`
 }
 
-func (tweetInfo *TweetInfo) CreateCsv(text string) (csvFile *os.File, err error) {
+func (tweetInfo *TweetInfo) CreateCsv(text string, noDetail bool) (csvFile *os.File, err error) {
 	lines := replaceLines(strings.Split(text, "\n"))
 	lastWords := lines[len(lines)-2]
 
@@ -50,6 +50,10 @@ func (tweetInfo *TweetInfo) CreateCsv(text string) (csvFile *os.File, err error)
 
 	// details
 	case strings.HasSuffix(lastWords, "とじる"), strings.HasSuffix(lastWords, "Close"):
+		if noDetail {
+			fmt.Println("skip detail")
+			return nil, nil
+		}
 		csvFile, err = tweetInfo.createCsvDetails(lines)
 	}
 	return

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ func main() {
 	location := flag.String("l", "us", "bigquery_location")
 	twitterId := flag.String("u", "", "twitter_id")
 	sizeStr := flag.String("s", "1", "search_size")
+	noDetail := flag.Bool("no-detail", false, "no_detail")
 	flag.Parse()
 
 	var rfa search.Rfa
@@ -18,5 +19,5 @@ func main() {
 	rfa.Location = *location
 	rfa.TwitterID = *twitterId
 	rfa.Size = *sizeStr
-	rfa.Search()
+	rfa.Search(search.NoDetail(*noDetail))
 }

--- a/search/search.go
+++ b/search/search.go
@@ -26,7 +26,26 @@ type Rfa struct {
 	Size      string `json:"size"`
 }
 
-func (rfa *Rfa) Search() {
+type SearchOpts struct {
+	NoDetail bool
+}
+
+type option func(*SearchOpts)
+
+func NoDetail(v bool) option {
+	return func(s *SearchOpts) {
+		s.NoDetail = v
+	}
+}
+
+func (rfa *Rfa) Search(opts ...option) {
+	s := &SearchOpts{
+		NoDetail: false,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+
 	size, _ := strconv.Atoi(rfa.Size)
 	lastExecutedAt := getLastExecutedAt(rfa.ProjectID, rfa.Location, rfa.TwitterID)
 
@@ -45,7 +64,7 @@ func (rfa *Rfa) Search() {
 		wgWorker.Add(1)
 		go func(r twitter.Rslt) {
 			defer wgWorker.Done()
-			worker(r, &rfa.ProjectID, &rfa.TwitterID)
+			worker(r, &rfa.ProjectID, &rfa.TwitterID, s.NoDetail)
 		}(rslt)
 	}
 	wgWorker.Wait()
@@ -75,14 +94,14 @@ func getLastExecutedAt(projectID string, location string, twitterId string) time
 	return lastExecutedAt
 }
 
-func worker(r twitter.Rslt, projectID *string, twitterId *string) {
+func worker(r twitter.Rslt, projectID *string, twitterId *string, noDetail bool) {
 	// Detect images and load data to BigQuery
 	wgMedia := new(sync.WaitGroup)
 	for _, url := range r.MediaUrlHttps {
 		wgMedia.Add(1)
 		go func(u string) {
 			defer wgMedia.Done()
-			detecter(*projectID, *twitterId, r.CreatedAt, u)
+			detecter(*projectID, *twitterId, r.CreatedAt, u, noDetail)
 		}(url)
 	}
 	wgMedia.Wait()
@@ -99,7 +118,7 @@ func worker(r twitter.Rslt, projectID *string, twitterId *string) {
 	}
 }
 
-func detecter(projectID string, twitterId string, createdAt time.Time, url string) {
+func detecter(projectID string, twitterId string, createdAt time.Time, url string, noDetail bool) {
 	fmt.Println(url)
 	file, err := twitter.GetImage(url)
 	if err != nil {
@@ -117,9 +136,13 @@ func detecter(projectID string, twitterId string, createdAt time.Time, url strin
 		CreatedAt: createdAt,
 		ImageUrl:  url,
 	}
-	csvFile, err := tweetInfo.CreateCsv(text)
+	csvFile, err := tweetInfo.CreateCsv(text, noDetail)
 	if err != nil {
 		log.Fatal(err)
+	}
+	if csvFile == nil {
+		// for no-detail
+		return
 	}
 
 	err = bq.LoadCsv(projectID, csvFile)


### PR DESCRIPTION
たまにSetDetailが失敗する。CloudVisionAPIがラベル、値、ラベル、値、...の順番で返さなかったときに発生する。
ツイートのviaがNintendo Switch Shareのときに発生するかも