### PR TITLE
Fix error handle failed find quantity and remove no-detail

### DIFF
--- a/bq/csv_test.go
+++ b/bq/csv_test.go
@@ -2,6 +2,7 @@ package bq
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -42,5 +43,60 @@ func TestReplaceLines(t *testing.T) {
 			err := errors.Errorf("Fail.\n[out ]: %s\n[want]: %s", out, want)
 			t.Error(err)
 		}
+	}
+}
+
+func TestCreateCsvDetails(t *testing.T) {
+	tweetInfo := TweetInfo{
+		TwitterId: "test",
+		CreatedAt: time.Time{},
+		ImageUrl:  "https://example.com",
+	}
+	in_lines := []string{
+		"本日の運動結果", "test", "R", "画面を撮影する",
+		"リングコン押しこみ",
+		"611回(3558回)",
+		"リングコン下押しこみ",
+		"9回(47回)",
+		"アームツイスト",
+		"282回(611回)",
+		"リングコン引っぱり",
+		"6回(66回)",
+		"バンザイコシフリ",
+		"235回(376回)",
+		"おなか押しこみスクワット",
+		"1回(30)",
+		"モモアゲアゲ",
+		"108回(1019回)",
+		"ジョギング",
+		"215m(4479m)",
+		"ねじり体側のポーズ",
+		"96回(96回)",
+		"ダッシュ",
+		"160m(9175m)",
+		"ワイドスクワット",
+		"88回(198回)",
+		"モモあげ",
+		"131m(534m)",
+		"バンザイモーニング",
+		"66回(251回)",
+		"スクワットキープ",
+		"10秒(158秒)",
+		"英雄2のポーズ",
+		"リングコン下押しこみキープ",
+		"リングコン引っぱりキープ",
+		"60回(156回)",
+		"4秒(52秒)",
+		"モモデプッシュ",
+		"22回(266回)",
+		"4秒(376秒)",
+		"おなか押しこみ",
+		"20回(182回)",
+		"カッコ内はプレイ開始からの累計値です", "とじる", " ",
+	}
+
+	_, err := tweetInfo.createCsvDetails(in_lines)
+	if err != nil {
+		t.Error(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ func main() {
 	location := flag.String("l", "us", "bigquery_location")
 	twitterId := flag.String("u", "", "twitter_id")
 	sizeStr := flag.String("s", "1", "search_size")
-	noDetail := flag.Bool("no-detail", false, "no_detail")
 	flag.Parse()
 
 	var rfa search.Rfa
@@ -19,5 +18,5 @@ func main() {
 	rfa.Location = *location
 	rfa.TwitterID = *twitterId
 	rfa.Size = *sizeStr
-	rfa.Search(search.NoDetail(*noDetail))
+	rfa.Search()
 }


### PR DESCRIPTION
- Add error handle on failed find quantity
- remove no-detail option

quantityLineのRegex.FindAllが失敗したときのパニック回避処理を追加した。
Detailsの登録で失敗することが（おそらく）なくなったので、一時的に追加していたno-detailオプションを消した
（分けるべきだったか）